### PR TITLE
🔧 Refine: Optimize CI workflow and fix accessibility warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: yarn lint
       - name: Build
         run: yarn build
+      - name: Run unit tests
+        run: yarn test:unit
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -49,16 +51,19 @@ jobs:
           path: out/
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(yarn list --pattern @playwright/test | grep @playwright/test | grep -oP '@\K[0-9.]+')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p 'require("@playwright/test/package.json").version')" >> $GITHUB_OUTPUT
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ steps.playwright-version.outputs.version }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium webkit
-      - name: Run unit tests
-        run: yarn test:unit
+      - name: Install Playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium webkit
       - name: Run E2E tests
         run: yarn test:e2e
       - name: Upload Playwright report

--- a/components/backup-modal.tsx
+++ b/components/backup-modal.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -35,6 +36,9 @@ export function BackupModal({ onDownload, onUpload }: BackupModalProps) {
       <DialogContent className="sm:max-w-[380px] rounded-2xl border border-pastel-border-green p-6 shadow-xl">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-center mb-6 tracking-tight">Backup Options</DialogTitle>
+          <DialogDescription className="sr-only">
+            Download your current work as a backup file or load a previous backup.
+          </DialogDescription>
         </DialogHeader>
         <div className="grid grid-cols-1 gap-3 mt-2">
           <Button

--- a/components/export-modal.tsx
+++ b/components/export-modal.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -42,6 +43,9 @@ export function ExportModal({ onExport, isExporting }: ExportModalProps) {
       <DialogContent className="sm:max-w-[400px] rounded-2xl border border-pastel-border-purple p-6 shadow-xl">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-center mb-6 tracking-tight">Export Outline</DialogTitle>
+          <DialogDescription className="sr-only">
+            Choose a format to export your sermon outline.
+          </DialogDescription>
         </DialogHeader>
         <div className="grid grid-cols-2 gap-3 mt-2">
           {exportOptions.map((option) => (


### PR DESCRIPTION
This PR introduces practical enhancements to the CI pipeline and accessibility:

1. **CI Optimization**:
   - Moves `Run unit tests` to the `lint-and-build` job to allow parallel execution with the build, providing faster feedback.
   - Refines the Playwright caching strategy: it now caches the browser binaries and only runs `npx playwright install-deps` on a cache hit, which is significantly faster than a full install.
   - Replaces the slow `yarn list` version extraction with a robust and fast `node -p` command.

2. **Accessibility (ARIA) Improvements**:
   - Added `DialogDescription` with `sr-only` to both `ExportModal` and `BackupModal`. This resolves Radix UI/Aria warnings about missing descriptors and improves the experience for screen reader users.

These changes reduce the overall time for the "Test" job and improve the general health of the codebase.

---
*PR created automatically by Jules for task [5657485357630902804](https://jules.google.com/task/5657485357630902804) started by @allemandi*