### PR TITLE
🔧 Refine: Sermon Outline UX and Accessibility Enhancements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -130,8 +130,8 @@ export default function SermonOutlinePlanner() {
       <span id="dnd-instructions" className="sr-only">
         To pick up a draggable item, press the space bar. While dragging, use the arrow keys to move the item. Press space again to drop the item in its new position, or press escape to cancel.
       </span>
-      <div className="container mx-auto px-4 py-8 max-w-6xl pb-24">
-        <header className="mb-10 space-y-6">
+      <div className="container mx-auto px-3 sm:px-4 py-6 sm:py-8 max-w-6xl pb-24">
+        <header className="mb-8 sm:mb-10 space-y-6">
           <div className="flex justify-between items-center gap-4">
             <div className="flex items-center gap-3 group">
               <div className="p-2 bg-pastel-blue/40 border-2 border-pastel-border-blue rounded-xl shadow-sm transition-transform group-hover:rotate-3">
@@ -155,8 +155,8 @@ export default function SermonOutlinePlanner() {
             </Button>
           </div>
 
-          <nav className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 bg-card/40 backdrop-blur-md rounded-2xl border border-border shadow-sm">
-            <div className="flex flex-wrap items-center gap-2">
+          <nav className="flex flex-col md:flex-row md:items-center justify-between gap-4 p-3 sm:p-4 bg-card/40 backdrop-blur-md rounded-2xl border border-border shadow-sm">
+            <div className="flex flex-wrap items-center justify-center sm:justify-start gap-2">
               <Button
                 onClick={saveOutlineToLocalStorage}
                 variant="pastel"
@@ -183,6 +183,7 @@ export default function SermonOutlinePlanner() {
               onClick={handleResetAll}
               variant="pastel-rose"
               size="sm"
+              className="w-full md:w-auto"
               aria-label="Reset the entire sermon outline"
             >
               <RefreshCw className="h-4 w-4 mr-1.5" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ import {
   type DragStartEvent,
   type DragOverEvent,
   type DragEndEvent,
-  defaultAnnouncements,
 } from "@dnd-kit/core"
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifiers"
@@ -26,6 +25,7 @@ import Footer from "@/components/footer"
 import { ExportModal } from "@/components/export-modal"
 import { BackupModal } from "@/components/backup-modal"
 import { useSermonOutline } from "@/hooks/use-sermon-outline"
+import { createAnnouncements } from "@/lib/dnd-announcements"
 import {
   Dialog,
   DialogContent,
@@ -51,6 +51,9 @@ export default function SermonOutlinePlanner() {
     addBlockToSection,
     removeBlock,
     removeSection,
+    confirmRemoveSection,
+    cancelRemoveSection,
+    sectionToDelete,
     handleExport,
     isExporting,
     isSaving,
@@ -120,32 +123,7 @@ export default function SermonOutlinePlanner() {
 
   if (!mounted) return <div className="min-h-screen bg-background" />
 
-  const announcements = {
-    ...defaultAnnouncements,
-    onDragStart({ active }: DragStartEvent) {
-      const activeSection = sections.find((s) => s.id === active.id)
-      return `Picked up section ${activeSection?.title || active.id}.`
-    },
-    onDragOver({ active, over }: DragOverEvent) {
-      if (over) {
-        const activeSection = sections.find((s) => s.id === active.id)
-        const overSection = sections.find((s) => s.id === over.id)
-        return `Section ${activeSection?.title || active.id} was moved over section ${overSection?.title || over.id}.`
-      }
-      return `Section ${active.id} is no longer over a droppable area.`
-    },
-    onDragEnd({ active, over }: DragEndEvent) {
-      if (over) {
-        const activeSection = sections.find((s) => s.id === active.id)
-        const overSection = sections.find((s) => s.id === over.id)
-        return `Section ${activeSection?.title || active.id} was dropped over section ${overSection?.title || over.id}.`
-      }
-      return `Section ${active.id} was dropped.`
-    },
-    onDragCancel({ active }: DragEndEvent) {
-      return `Dragging was cancelled. Section ${active.id} was dropped.`
-    },
-  }
+  const announcements = createAnnouncements("section", sections, (s) => s.title)
 
   return (
     <div className="min-h-screen bg-background text-foreground transition-colors duration-300">
@@ -229,6 +207,27 @@ export default function SermonOutlinePlanner() {
                 </Button>
                 <Button variant="destructive" onClick={confirmResetAll} className="flex-1 order-1 sm:order-2">
                   Yes, Reset
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={sectionToDelete !== null} onOpenChange={(open) => !open && cancelRemoveSection()}>
+          <DialogContent className="rounded-2xl border border-pastel-border-rose shadow-xl sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="text-xl font-bold text-center">Remove Section?</DialogTitle>
+            </DialogHeader>
+            <div className="mt-4 space-y-6">
+              <p className="text-center text-muted-foreground text-sm font-medium">
+                Are you sure you want to remove "{sectionToDelete !== null ? sections[sectionToDelete]?.title : ""}"? This action cannot be undone.
+              </p>
+              <div className="flex flex-col sm:flex-row justify-center gap-3">
+                <Button variant="outline" onClick={cancelRemoveSection} className="flex-1 order-2 sm:order-1">
+                  Cancel
+                </Button>
+                <Button variant="destructive" onClick={confirmRemoveSection} className="flex-1 order-1 sm:order-2">
+                  Yes, Remove
                 </Button>
               </div>
             </div>

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -131,25 +131,25 @@ export function OutlineBlock({
 
         <div className="flex-grow space-y-3 group/block">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="relative min-w-[120px] flex items-center group/label">
+            <div className="flex items-center gap-2 flex-grow overflow-hidden">
+              <div className="relative min-w-[80px] xs:min-w-[120px] max-w-full flex items-center group/label">
                 {isEditingLabel ? (
                   <Input
                     value={labelValue}
                     onChange={handleLabelChange}
                     onBlur={handleLabelBlur}
                     onKeyDown={handleLabelKeyDown}
-                    className="h-7 text-[10px] font-bold rounded-md bg-background border-2 w-full focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary"
+                    className="h-7 text-[10px] sm:text-xs font-bold rounded-md bg-background border-2 w-full focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary"
                     autoFocus
                     aria-label={`Edit label for ${block.label}`}
                   />
                 ) : (
                   <button
-                    className="text-xs font-bold text-inherit opacity-70 uppercase tracking-widest cursor-pointer hover:opacity-100 transition-all px-1.5 py-0.5 bg-muted/30 rounded w-full border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:bg-muted/50 flex items-center justify-between"
+                    className="text-[10px] sm:text-xs font-bold text-inherit opacity-70 uppercase tracking-widest cursor-pointer hover:opacity-100 transition-all px-1.5 py-0.5 bg-muted/30 rounded w-full border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:bg-muted/50 flex items-center justify-between overflow-hidden"
                     onClick={() => setIsEditingLabel(true)}
                     aria-label={`Edit label: ${block.label}`}
                   >
-                    <span>{block.label}</span>
+                    <span className="truncate mr-1">{block.label}</span>
                     <Pencil className="h-3 w-3 text-muted-foreground opacity-40 group-hover/label:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
                   </button>
                 )}
@@ -164,11 +164,11 @@ export function OutlineBlock({
                   e.stopPropagation();
                   onResetLabel();
                 }}
-                className="h-6 px-1.5 text-xs font-bold uppercase tracking-tight hover:bg-muted/50 rounded-md text-inherit"
+                className="h-6 px-1.5 text-[10px] sm:text-xs font-bold uppercase tracking-tight hover:bg-muted/50 rounded-md text-inherit shrink-0"
                 aria-label={`Reset label for block ${block.label} to default`}
               >
-                <span>Reset</span>
-                <RefreshCw className="h-3 w-3 ml-1 text-muted-foreground" />
+                <span className="hidden xs:inline">Reset</span>
+                <RefreshCw className="h-3 w-3 xs:ml-1 text-muted-foreground" />
               </Button>
               {showRemoveButton && (
                 <Button

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -110,28 +110,28 @@ export function OutlineBlock({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "rounded-xl border p-4 transition-all duration-200 shadow-sm outline-none",
+        "rounded-xl border p-2.5 sm:p-4 transition-all duration-200 shadow-sm outline-none",
         isDragging ? "shadow-xl scale-[1.02] ring-2 ring-primary/20 bg-card" : "",
         getBlockStyles(block.type)
       )}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-start gap-2 sm:gap-3">
         <button
           {...attributes}
           {...listeners}
-          className="flex-shrink-0 cursor-grab mt-1 p-1.5 rounded-md hover:bg-muted transition-colors bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          className="flex-shrink-0 cursor-grab mt-1 p-1 sm:p-1.5 rounded-md hover:bg-muted transition-colors bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           data-drag-handle
           aria-label={`Drag to reorder block: ${block.label}`}
           aria-roledescription="drag handle"
           aria-describedby="dnd-instructions"
           style={{ touchAction: 'none' }}
         >
-          <GripVertical className="h-4 w-4 text-muted-foreground" />
+          <GripVertical className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />
         </button>
 
-        <div className="flex-grow space-y-3 group/block">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 flex-grow overflow-hidden">
+        <div className="flex-grow space-y-2 sm:space-y-3 group/block min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 flex-grow min-w-0 overflow-hidden">
               <div className="relative min-w-[80px] xs:min-w-[120px] max-w-full flex items-center group/label">
                 {isEditingLabel ? (
                   <Input
@@ -184,7 +184,7 @@ export function OutlineBlock({
             </div>
           </div>
 
-          <div className="min-h-[60px] w-full" style={{ whiteSpace: 'pre-line' }}>
+          <div className="min-h-[50px] sm:min-h-[60px] w-full" style={{ whiteSpace: 'pre-line' }}>
             {isEditing ? (
               <textarea
                 ref={textareaRef}
@@ -193,7 +193,7 @@ export function OutlineBlock({
                 onBlur={handleContentBlur}
                 onKeyDown={handleContentKeyDown}
                 className={cn(
-                  "w-full min-h-[70px] p-3 rounded-lg bg-muted/20 focus:outline-none focus:ring-2 transition-all text-sm font-medium focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary",
+                  "w-full min-h-[60px] sm:min-h-[70px] p-2 sm:p-3 rounded-lg bg-muted/20 focus:outline-none focus:ring-2 transition-all text-sm font-medium focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary",
                   getTextAreaStyles(block.type)
                 )}
                 placeholder={block.placeholder}
@@ -204,15 +204,15 @@ export function OutlineBlock({
             ) : (
               <button
                 className={cn(
-                  "w-full min-h-[60px] p-3 rounded-lg transition-all cursor-text text-sm font-medium border-2 border-transparent group-hover/block:border-muted-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col text-left",
+                  "w-full min-h-[50px] sm:min-h-[60px] p-2 sm:p-3 rounded-lg transition-all cursor-text text-sm font-medium border-2 border-transparent group-hover/block:border-muted-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col text-left",
                   content ? "bg-muted/5 text-foreground" : "bg-muted/20 text-muted-foreground/50 dark:text-muted-foreground/60 italic"
                 )}
                 onClick={() => setIsEditing(true)}
                 aria-label={content ? `Edit content for ${block.label}` : `Add content to ${block.label}`}
               >
-                <div className="flex-grow">{content || block.placeholder}</div>
+                <div className="flex-grow break-words">{content || block.placeholder}</div>
                 <div className="self-end mt-1 opacity-20 group-hover/block:opacity-100 transition-opacity">
-                  <Pencil className="h-3.5 w-3.5 text-muted-foreground/50" aria-hidden="true" />
+                  <Pencil className="h-3 sm:h-3.5 w-3 sm:w-3.5 text-muted-foreground/50" aria-hidden="true" />
                 </div>
               </button>
             )}

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -46,7 +46,8 @@ export function OutlineBlock({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : 1,
+    opacity: isDragging ? 0.6 : 1,
+    zIndex: isDragging ? 50 : 0,
   }
 
   useEffect(() => {
@@ -110,7 +111,7 @@ export function OutlineBlock({
       style={style}
       className={cn(
         "rounded-xl border p-4 transition-all duration-200 shadow-sm outline-none",
-        isDragging ? "z-10 shadow-lg scale-[1.01] ring-2 ring-primary/5" : "",
+        isDragging ? "shadow-xl scale-[1.02] ring-2 ring-primary/20 bg-card" : "",
         getBlockStyles(block.type)
       )}
     >
@@ -144,12 +145,12 @@ export function OutlineBlock({
                   />
                 ) : (
                   <button
-                    className="text-[10px] font-bold text-inherit opacity-70 uppercase tracking-widest cursor-pointer hover:opacity-100 transition-all px-1.5 py-0.5 bg-muted/30 rounded w-full border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:bg-muted/50 flex items-center justify-between"
+                    className="text-xs font-bold text-inherit opacity-70 uppercase tracking-widest cursor-pointer hover:opacity-100 transition-all px-1.5 py-0.5 bg-muted/30 rounded w-full border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:bg-muted/50 flex items-center justify-between"
                     onClick={() => setIsEditingLabel(true)}
                     aria-label={`Edit label: ${block.label}`}
                   >
                     <span>{block.label}</span>
-                    <Pencil className="h-2.5 w-2.5 opacity-40 group-hover/label:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
+                    <Pencil className="h-3 w-3 text-muted-foreground opacity-40 group-hover/label:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
                   </button>
                 )}
               </div>
@@ -163,11 +164,11 @@ export function OutlineBlock({
                   e.stopPropagation();
                   onResetLabel();
                 }}
-                className="h-6 px-1.5 text-[9px] font-bold uppercase tracking-tight hover:bg-muted/50 rounded-md text-inherit"
+                className="h-6 px-1.5 text-xs font-bold uppercase tracking-tight hover:bg-muted/50 rounded-md text-inherit"
                 aria-label={`Reset label for block ${block.label} to default`}
               >
                 <span>Reset</span>
-                <RefreshCw className="h-2.5 w-2.5 ml-1" />
+                <RefreshCw className="h-3 w-3 ml-1 text-muted-foreground" />
               </Button>
               {showRemoveButton && (
                 <Button

--- a/components/outline-section.tsx
+++ b/components/outline-section.tsx
@@ -9,8 +9,9 @@ import { Input } from "@/components/ui/input"
 import type { Section } from "@/lib/types"
 import { cn, getSectionStyles } from "@/lib/utils"
 import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
-import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, KeyboardSensor, TouchSensor, type DragStartEvent, type DragOverEvent, type DragEndEvent, defaultAnnouncements } from "@dnd-kit/core"
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, KeyboardSensor, TouchSensor, type DragStartEvent, type DragOverEvent, type DragEndEvent } from "@dnd-kit/core"
 import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifiers"
+import { createAnnouncements } from "@/lib/dnd-announcements"
 
 interface OutlineSectionProps {
   section: Section
@@ -81,39 +82,17 @@ export function OutlineSection({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  const announcements = {
-    ...defaultAnnouncements,
-    onDragStart({ active }: DragStartEvent) {
-      const activeBlock = section.blocks.find((b) => b.id === active.id)
-      return `Picked up block ${activeBlock?.label || active.id}.`
-    },
-    onDragOver({ active, over }: DragOverEvent) {
-      if (over) {
-        const activeBlock = section.blocks.find((b) => b.id === active.id)
-        const overBlock = section.blocks.find((b) => b.id === over.id)
-        return `Block ${activeBlock?.label || active.id} was moved over block ${overBlock?.label || over.id}.`
-      }
-      return `Block ${active.id} is no longer over a droppable area.`
-    },
-    onDragEnd({ active, over }: DragEndEvent) {
-      if (over) {
-        const activeBlock = section.blocks.find((b) => b.id === active.id)
-        const overBlock = section.blocks.find((b) => b.id === over.id)
-        return `Block ${activeBlock?.label || active.id} was dropped over block ${overBlock?.label || over.id}.`
-      }
-      return `Block ${active.id} was dropped.`
-    },
-    onDragCancel({ active }: DragEndEvent) {
-      return `Dragging was cancelled. Block ${active.id} was dropped.`
-    },
-  }
+  const announcements = createAnnouncements("block", section.blocks, (b) => b.label)
 
   return (
     <Card
       ref={cardRef}
       className={cn("transition-all border rounded-2xl shadow-sm overflow-hidden outline-none", getSectionStyles(section.type))}
     >
-      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between pb-4 pt-6 pl-10 pr-4 sm:px-8 gap-3">
+      <CardHeader className={cn(
+        "flex flex-col sm:flex-row items-start sm:items-center justify-between pb-4 pt-6 pr-4 sm:px-8 gap-3",
+        section.type === "body" ? "pl-10" : "pl-4 sm:pl-8"
+      )}>
         <div className="flex items-center gap-3 min-w-[200px] group/title">
           {isEditingTitle ? (
             <Input
@@ -147,21 +126,21 @@ export function OutlineSection({
               e.stopPropagation();
               onResetTitle(sectionIndex);
             }}
-            className="h-7 px-2 text-[10px] font-bold uppercase tracking-wider hover:bg-background/50 text-inherit"
+            className="h-7 px-2 text-xs font-bold uppercase tracking-wider hover:bg-background/50 text-inherit"
             aria-label={`Reset title for section ${section.title} to default`}
           >
             <span className="hidden sm:inline">Reset Title</span>
-            <RefreshCw className="h-3 w-3 sm:ml-1.5" />
+            <RefreshCw className="h-3.5 w-3.5 sm:ml-1.5 text-muted-foreground" />
           </Button>
           <Button
             variant="outline"
             size="xs"
             onClick={onAddBlock}
-            className="h-7 px-2 text-[10px] font-bold uppercase tracking-wider bg-background/50 hover:bg-background border"
+            className="h-7 px-2 text-xs font-bold uppercase tracking-wider bg-background/50 hover:bg-background border"
             aria-label={`Add a new block to section ${section.title}`}
           >
             <span>Add Block</span>
-            <Plus className="h-3 w-3 ml-1.5" />
+            <Plus className="h-3.5 w-3.5 ml-1.5 text-muted-foreground" />
           </Button>
           {section.type === "body" && (
             <Button

--- a/components/outline-section.tsx
+++ b/components/outline-section.tsx
@@ -90,35 +90,35 @@ export function OutlineSection({
       className={cn("transition-all border rounded-2xl shadow-sm overflow-hidden outline-none", getSectionStyles(section.type))}
     >
       <CardHeader className={cn(
-        "flex flex-col sm:flex-row items-start sm:items-center justify-between pb-4 pt-6 pr-4 sm:px-8 gap-3",
-        section.type === "body" ? "pl-10" : "pl-4 sm:pl-8"
+        "flex flex-col sm:flex-row items-start sm:items-center justify-between pb-4 pt-5 sm:pt-6 pr-3 sm:pr-8 gap-3",
+        section.type === "body" ? "pl-9 sm:pl-10" : "pl-3 sm:pl-8"
       )}>
-        <div className="flex items-center gap-3 min-w-[200px] group/title">
+        <div className="flex items-center gap-2 min-w-0 flex-1 group/title">
           {isEditingTitle ? (
             <Input
               value={titleValue}
               onChange={handleTitleChange}
               onBlur={handleTitleBlur}
               onKeyDown={handleTitleKeyDown}
-              className="h-9 text-lg sm:text-xl font-bold bg-background/50 rounded-md border-2 focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary"
+              className="h-8 sm:h-9 text-base sm:text-xl font-bold bg-background/50 rounded-md border-2 focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary w-full"
               autoFocus
               aria-label={`Edit section title for ${section.title}`}
             />
           ) : (
             <button
-              className="text-lg sm:text-xl font-bold cursor-pointer hover:opacity-70 transition-all tracking-tight text-inherit py-1 border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:rounded-md flex items-center gap-2 w-full text-left"
+              className="text-base sm:text-xl font-bold cursor-pointer hover:opacity-70 transition-all tracking-tight text-inherit py-1 border-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:rounded-md flex items-center gap-2 min-w-0 text-left overflow-hidden"
               onClick={() => setIsEditingTitle(true)}
               aria-label={`Edit section title: ${section.title}`}
             >
-              <CardTitle className="text-inherit font-bold">
+              <CardTitle className="text-inherit font-bold truncate">
                 {section.title}
               </CardTitle>
-              <Pencil className="h-4 w-4 opacity-20 group-hover/title:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
+              <Pencil className="h-3.5 w-3.5 sm:h-4 sm:w-4 opacity-20 group-hover/title:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
             </button>
           )}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 sm:gap-2 shrink-0">
           <Button
             variant="ghost"
             size="xs"
@@ -155,7 +155,7 @@ export function OutlineSection({
           )}
         </div>
       </CardHeader>
-      <CardContent className="space-y-4 pb-6 px-4 sm:px-8">
+      <CardContent className="space-y-4 pb-5 sm:pb-6 px-3 sm:px-8">
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}

--- a/components/outline-section.tsx
+++ b/components/outline-section.tsx
@@ -126,7 +126,7 @@ export function OutlineSection({
               e.stopPropagation();
               onResetTitle(sectionIndex);
             }}
-            className="h-7 px-2 text-xs font-bold uppercase tracking-wider hover:bg-background/50 text-inherit"
+            className="h-7 px-2 text-[10px] sm:text-xs font-bold uppercase tracking-wider hover:bg-background/50 text-inherit"
             aria-label={`Reset title for section ${section.title} to default`}
           >
             <span className="hidden sm:inline">Reset Title</span>
@@ -136,11 +136,11 @@ export function OutlineSection({
             variant="outline"
             size="xs"
             onClick={onAddBlock}
-            className="h-7 px-2 text-xs font-bold uppercase tracking-wider bg-background/50 hover:bg-background border"
+            className="h-7 px-2 text-[10px] sm:text-xs font-bold uppercase tracking-wider bg-background/50 hover:bg-background border"
             aria-label={`Add a new block to section ${section.title}`}
           >
-            <span>Add Block</span>
-            <Plus className="h-3.5 w-3.5 ml-1.5 text-muted-foreground" />
+            <span className="hidden xs:inline">Add Block</span>
+            <Plus className="h-3.5 w-3.5 xs:ml-1.5 text-muted-foreground" />
           </Button>
           {section.type === "body" && (
             <Button

--- a/components/sortable-section.tsx
+++ b/components/sortable-section.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { GripVertical } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 interface SortableSectionProps {
   id: string
@@ -20,15 +21,22 @@ export function SortableSection({ id, children, title }: SortableSectionProps & 
 
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition: 'opacity 100ms ease',
-    opacity: isDragging ? 0.5 : 1,
+    transition: 'opacity 100ms ease, transform 200ms ease',
+    opacity: isDragging ? 0.6 : 1,
     position: "relative" as const,
-    zIndex: isDragging ? 1 : 0,
+    zIndex: isDragging ? 50 : 0,
     whiteSpace: 'pre-line',
   }
 
   return (
-    <div ref={setNodeRef} style={style} className="relative">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "relative transition-shadow duration-200",
+        isDragging ? "shadow-2xl rounded-2xl scale-[1.02]" : ""
+      )}
+    >
       <button
         type="button"
         className="absolute top-6 left-2 sm:left-4 cursor-grab p-1 rounded hover:bg-muted z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"

--- a/hooks/use-sermon-outline.ts
+++ b/hooks/use-sermon-outline.ts
@@ -138,6 +138,7 @@ export function useSermonOutline() {
   const [newBlockId, setNewBlockId] = useState<string | null>(null)
   const { toast } = useToast()
   const [showResetModal, setShowResetModal] = useState(false)
+  const [sectionToDelete, setSectionToDelete] = useState<number | null>(null)
 
   const bodySectionIds = useMemo(() =>
     sections.filter((section) => section.type === "body").map((section) => section.id),
@@ -421,16 +422,27 @@ export function useSermonOutline() {
         return
       }
 
-      setSections((prev) => prev.filter((_, i) => i !== sectionIndex))
-
-      toast({
-        title: "Section Removed",
-        description: "The section has been removed from your outline.",
-        duration: 3000,
-      })
+      setSectionToDelete(sectionIndex)
     },
     [sections, toast]
   )
+
+  const confirmRemoveSection = useCallback(() => {
+    if (sectionToDelete === null) return
+
+    setSections((prev) => prev.filter((_, i) => i !== sectionToDelete))
+    setSectionToDelete(null)
+
+    toast({
+      title: "Section Removed",
+      description: "The section has been removed from your outline.",
+      duration: 3000,
+    })
+  }, [sectionToDelete, toast])
+
+  const cancelRemoveSection = useCallback(() => {
+    setSectionToDelete(null)
+  }, [])
 
   const [isExporting, setIsExporting] = useState(false)
 
@@ -579,6 +591,9 @@ export function useSermonOutline() {
     addBlockToSection,
     removeBlock,
     removeSection,
+    confirmRemoveSection,
+    cancelRemoveSection,
+    sectionToDelete,
     handleExport,
     isExporting,
     isSaving,

--- a/lib/dnd-announcements.ts
+++ b/lib/dnd-announcements.ts
@@ -1,0 +1,36 @@
+import { DragStartEvent, DragOverEvent, DragEndEvent, defaultAnnouncements } from "@dnd-kit/core"
+
+export const createAnnouncements = <T extends { id: string }>(
+  itemName: string,
+  items: T[],
+  getTitle: (item: T) => string | undefined
+) => ({
+  ...defaultAnnouncements,
+  onDragStart({ active }: DragStartEvent) {
+    const activeItem = items.find((i) => i.id === active.id)
+    return `Picked up ${itemName} ${activeItem ? getTitle(activeItem) : active.id}.`
+  },
+  onDragOver({ active, over }: DragOverEvent) {
+    if (over) {
+      const activeItem = items.find((i) => i.id === active.id)
+      const overItem = items.find((i) => i.id === over.id)
+      const activeName = activeItem ? getTitle(activeItem) : active.id
+      const overName = overItem ? getTitle(overItem) : over.id
+      return `${itemName} ${activeName} was moved over ${itemName} ${overName}.`
+    }
+    return `${itemName} ${active.id} is no longer over a droppable area.`
+  },
+  onDragEnd({ active, over }: DragEndEvent) {
+    if (over) {
+      const activeItem = items.find((i) => i.id === active.id)
+      const overItem = items.find((i) => i.id === over.id)
+      const activeName = activeItem ? getTitle(activeItem) : active.id
+      const overName = overItem ? getTitle(overItem) : over.id
+      return `${itemName} ${activeName} was dropped over ${itemName} ${overName}.`
+    }
+    return `${itemName} ${active.id} was dropped.`
+  },
+  onDragCancel({ active }: DragEndEvent) {
+    return `Dragging was cancelled. ${itemName} ${active.id} was dropped.`
+  },
+})

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,14 @@ const config: Config = {
     "*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
+    screens: {
+      'xs': '400px',
+      'sm': '640px',
+      'md': '768px',
+      'lg': '1024px',
+      'xl': '1280px',
+      '2xl': '1536px',
+    },
   	extend: {
   		colors: {
         pastel: {


### PR DESCRIPTION
This PR implements several focused improvements to the Sermon Outline Planner:

1. **UX Safety**: Added a confirmation dialog when deleting sections.
2. **Visual Affordance**: Enhanced the 'dragging' state for sections and blocks with better shadows and scaling.
3. **Accessibility**: 
   - Increased font size of 'Reset' and 'Add Block' buttons for better readability.
   - Improved contrast of icons in these buttons.
   - Standardized ARIA live region announcements for drag-and-drop operations.
4. **Code Quality**: Refactored repetitive DnD announcement logic into a reusable, type-safe utility.
5. **Consistency**: Fixed a padding issue where Intro/Conclusion sections were incorrectly using drag-handle-offset padding despite not being draggable.

---
*PR created automatically by Jules for task [17451686854938525838](https://jules.google.com/task/17451686854938525838) started by @allemandi*