### PR TITLE
🔧 Refine: Accessible Inline Editing — focus management, escape cancellation, and keyboard shortcuts

### DIFF
--- a/components/ui/editable-area.tsx
+++ b/components/ui/editable-area.tsx
@@ -30,6 +30,9 @@ export function EditableArea({
   const [isEditing, setIsEditing] = React.useState(autoFocus)
   const [localValue, setLocalValue] = React.useState(value)
   const textareaRef = React.useRef<HTMLTextAreaElement>(null)
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
+  const wasEditingRef = React.useRef(isEditing)
+  const isCancelingRef = React.useRef(false)
 
   React.useEffect(() => {
     setLocalValue(value)
@@ -43,7 +46,18 @@ export function EditableArea({
     }
   }, [isEditing])
 
+  React.useEffect(() => {
+    if (wasEditingRef.current && !isEditing) {
+      buttonRef.current?.focus()
+    }
+    wasEditingRef.current = isEditing
+  }, [isEditing])
+
   const handleBlur = () => {
+    if (isCancelingRef.current) {
+      isCancelingRef.current = false
+      return
+    }
     if (localValue !== value) {
       onSave(localValue)
     }
@@ -52,9 +66,13 @@ export function EditableArea({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Escape") {
+      isCancelingRef.current = true
       setLocalValue(value)
       onCancel?.()
       setIsEditing(false)
+    } else if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault()
+      handleBlur()
     }
   }
 
@@ -86,6 +104,7 @@ export function EditableArea({
 
   return (
     <button
+      ref={buttonRef}
       id={id ? `${id}-button` : undefined}
       type="button"
       className={cn(

--- a/components/ui/editable-field.tsx
+++ b/components/ui/editable-field.tsx
@@ -30,12 +30,26 @@ export function EditableField({
 }: EditableFieldProps) {
   const [isEditing, setIsEditing] = React.useState(autoFocus)
   const [localValue, setLocalValue] = React.useState(value)
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
+  const wasEditingRef = React.useRef(isEditing)
+  const isCancelingRef = React.useRef(false)
 
   React.useEffect(() => {
     setLocalValue(value)
   }, [value])
 
+  React.useEffect(() => {
+    if (wasEditingRef.current && !isEditing) {
+      buttonRef.current?.focus()
+    }
+    wasEditingRef.current = isEditing
+  }, [isEditing])
+
   const handleBlur = () => {
+    if (isCancelingRef.current) {
+      isCancelingRef.current = false
+      return
+    }
     if (localValue !== value) {
       onSave(localValue)
     }
@@ -46,6 +60,7 @@ export function EditableField({
     if (e.key === "Enter") {
       handleBlur()
     } else if (e.key === "Escape") {
+      isCancelingRef.current = true
       setLocalValue(value)
       onCancel?.()
       setIsEditing(false)
@@ -69,6 +84,7 @@ export function EditableField({
 
   return (
     <button
+      ref={buttonRef}
       id={id ? `${id}-button` : undefined}
       type="button"
       className={cn(

--- a/tests/unit/editable-components.test.tsx
+++ b/tests/unit/editable-components.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { EditableField } from '@/components/ui/editable-field';
+import { EditableArea } from '@/components/ui/editable-area';
+
+describe('EditableField', () => {
+  it('renders trigger button with value and label', () => {
+    render(<EditableField value="Sermon Title" onSave={vi.fn()} label="sermon title" id="test-field" />);
+    const button = screen.getByRole('button', { name: /edit sermon title: sermon title/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Sermon Title');
+  });
+
+  it('enters editing mode on click and saves on Enter', () => {
+    const handleSave = vi.fn();
+    render(<EditableField value="Old Title" onSave={handleSave} label="sermon title" id="test-field" />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('Old Title');
+
+    fireEvent.change(input, { target: { value: 'New Title' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(handleSave).toHaveBeenCalledWith('New Title');
+  });
+
+  it('cancels edit and does not call onSave when Escape is pressed', () => {
+    const handleSave = vi.fn();
+    const handleCancel = vi.fn();
+    render(
+      <EditableField
+        value="Original Title"
+        onSave={handleSave}
+        onCancel={handleCancel}
+        label="sermon title"
+        id="test-field"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'Changed Title' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(handleCancel).toHaveBeenCalled();
+    expect(handleSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('restores focus to trigger button on exit', () => {
+    render(<EditableField value="Title" onSave={vi.fn()} label="sermon title" id="test-field" />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    const returnedButton = screen.getByRole('button');
+    expect(document.activeElement).toBe(returnedButton);
+  });
+});
+
+describe('EditableArea', () => {
+  it('renders trigger button with value or placeholder', () => {
+    render(
+      <EditableArea
+        value=""
+        placeholder="Type notes here..."
+        onSave={vi.fn()}
+        label="block content"
+        id="test-area"
+      />
+    );
+    const button = screen.getByRole('button', { name: /add block content/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Type notes here...');
+  });
+
+  it('saves content on Ctrl+Enter', () => {
+    const handleSave = vi.fn();
+    render(
+      <EditableArea
+        value="Initial Content"
+        onSave={handleSave}
+        label="block content"
+        id="test-area"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'Updated Content\nLine 2' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+
+    expect(handleSave).toHaveBeenCalledWith('Updated Content\nLine 2');
+  });
+
+  it('cancels edit on Escape without calling onSave', () => {
+    const handleSave = vi.fn();
+    const handleCancel = vi.fn();
+    render(
+      <EditableArea
+        value="Initial Content"
+        onSave={handleSave}
+        onCancel={handleCancel}
+        label="block content"
+        id="test-area"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'Some modified text' } });
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    expect(handleCancel).toHaveBeenCalled();
+    expect(handleSave).not.toHaveBeenCalled();
+  });
+
+  it('restores focus to trigger button on exit', () => {
+    render(
+      <EditableArea
+        value="Some text"
+        onSave={vi.fn()}
+        label="block content"
+        id="test-area"
+      />
+    );
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    const textarea = screen.getByRole('textbox');
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    const returnedButton = screen.getByRole('button');
+    expect(document.activeElement).toBe(returnedButton);
+  });
+});


### PR DESCRIPTION
🔧 Refine: Accessible Inline Editing — what, why, impact.

**What:** Refactored `EditableField` and `EditableArea` components to restore keyboard focus to the trigger button when exiting edit mode, fixed an issue where pressing Escape could trigger `onBlur` saving unintended edits, and added a `Ctrl+Enter` / `Cmd+Enter` shortcut to commit multiline textarea edits. Added comprehensive unit tests in `tests/unit/editable-components.test.tsx`.

**Why:** When keyboard users press Enter or Escape in an inline editable field, replacing the input element with a button previously lost DOM focus to `body`, breaking accessible tab order. Additionally, `onBlur` events firing upon input unmount could persist unintended edits on cancellation.

**Impact:** Dramatically improves keyboard navigation accessibility (WCAG), eliminates accidental edit persistence on Escape, and provides power-user keyboard shortcuts for sermon outline editing.

---
*PR created automatically by Jules for task [6469167427972546506](https://jules.google.com/task/6469167427972546506) started by @allemandi*